### PR TITLE
add support for devcontainer with python 3.10 and jupyter notebooks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	 "postCreateCommand": "pip install -r ./common/requirements.txt",
+
+	// Configure tool-specific properties.
+	 "customizations": {
+		"vscode": {
+			"extensions": [
+			  "ms-toolsai.jupyter",
+			  "ms-python.python"
+			]
+		  }
+	 }
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
dedicated branch for devcontainer, should be more easy to merge on main.  tested both locally and on codespaces