### PR TITLE
small fix Notebook 8

### DIFF
--- a/08-BingChatClone.ipynb
+++ b/08-BingChatClone.ipynb
@@ -29,6 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import requests\n",
     "from typing import Dict, List\n",
     "from pydantic import BaseModel, Extra, root_validator\n",


### PR DESCRIPTION
 This pull request addresses an issue in 08-BingChatClone.ipynb by adding the missing import statement for the 'os' library in the code. The import was absent, causing functionality issues, and this fix ensures the notebook functions as expected.